### PR TITLE
Fix stretching to avoid error due to cc > 1.0 and correct onebit()

### DIFF
--- a/src/VelocityChange/Stretching.jl
+++ b/src/VelocityChange/Stretching.jl
@@ -71,6 +71,13 @@ function stretching(ref::AbstractArray,cur::AbstractArray,t::AbstractArray,
     dv = 100. * dtfiner[argmax(CCfiner)]
     cc = maximum(CCfiner) # Maximum correlation coefficient of the refined analysis
 
+    # due to CubicSplineInterpolation, cc can be more than 1, causing an error when computing sqrt(1-X^2).
+    if cc > 1.0
+        cc = 1.0
+    elseif cc < -1.0
+        cc = -1.0
+    end
+
     # Error computation based on Weaver, R., C. Hadziioannou, E. Larose, and M.
     # Campillo (2011), On the precision of noise-correlation interferometry,
     # Geophys. J. Int., 185(3), 1384?1392

--- a/src/compute_fft.jl
+++ b/src/compute_fft.jl
@@ -145,7 +145,7 @@ function onebit!(R::RawData)
     R.x .= sign.(R.x)
     return nothing
 end
-onebit(R::RawData) = (U = deepcopy(R); sign!(U);return U)
+onebit(R::RawData) = (U = deepcopy(R); onebit!(U);return U)
 
 """
   remove_response!(S, stationXML, freqmin, freqmax)


### PR DESCRIPTION
Hi Tim, 

Can you modify two changes below?

1. In some cases, abs(cc) > 1.0 in Stretching.jl due to Cubic spline interpolation, which causes error when computing `err` in later line such as

```
julia> sqrt(1-1.1)
ERROR: DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).

```

So I would like to avoid this error like the commit. If you have another idea that would be great.

2. onebit() would be like this commit.
