### PR TITLE
return filename when saving jld2 files

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -28,6 +28,7 @@ function save_fft(F::FFTData, FFTOUT::String)
         file[chan][F.id] = F
     end
     close(file)
+    return filename
 end
 
 """
@@ -101,6 +102,7 @@ function save_corr(C::CorrData, CORROUT::String)
         file[C.comp][C.id] = C
     end
     close(file)
+    return filename
 end
 
 """


### PR DESCRIPTION
Addresses #80 to return the filename when saving to .jld2 file.